### PR TITLE
Fix: Shell variables :godmode:

### DIFF
--- a/.config/zsh/.zshrc
+++ b/.config/zsh/.zshrc
@@ -9,12 +9,12 @@ colors
 # ===============
 #     Alias
 # ===============
-source ~/.config/zsh/aliases.zsh
+source "$ZDOTDIR/aliases.zsh"
 
 # ===============
 #    Variables
 # ===============
-export ZSH_CACHE_DIR=$ZDOTDIR"/cache"
+export ZSH_CACHE_DIR="$ZDOTDIR/cache"
 export EDITOR="vim"
 export COLORTERM=truecolor
 setopt AUTO_CD
@@ -23,6 +23,7 @@ export HISTFILE=~/.zsh_history
 export HISTSIZE=1000
 export SAVEHIST=1000
 setopt SHARE_HISTORY
+source "$ZDOTDIR/color-manpages.zsh"
 zle_highlight=("paste:none")
 
 #gwsl
@@ -51,17 +52,17 @@ $ZDOTDIR/message.zsh
 #      Theme
 # ===============
 setopt prompt_subst
-source ~/.config/zsh/themes/redmarsh.zsh
+source "$ZDOTDIR/themes/redmarsh.zsh"
 
 # ===============
 #     Plugins
 # ===============
 
 # Dotenv:
-source ~/.config/zsh/plugs/dotenv/dotenv.plugin.zsh
+source "$ZDOTDIR/plugs/dotenv/dotenv.plugin.zsh"
 
 # zsh-autosuggestions:
-source ~/.config/zsh/plugs/zsh-autosuggestions/zsh-autosuggestions.zsh
+source "$ZDOTDIR/plugs/zsh-autosuggestions/zsh-autosuggestions.zsh"
 
 # zsh-syntax-highlighting
-source ~/.config/zsh/plugs/zsh-syntax/zsh-syntax-highlighting.zsh
+source "$ZDOTDIR/plugs/zsh-syntax/zsh-syntax-highlighting.zsh"

--- a/.config/zsh/color-manpages.zsh
+++ b/.config/zsh/color-manpages.zsh
@@ -1,0 +1,11 @@
+#!/usr/bin/zsh
+
+# Set less env variables to have different colors for man pages
+
+export LESS_TERMCAP_mb=$'\e[6m'          # begin blinking
+export LESS_TERMCAP_md=$'\e[34m'         # begin bold
+export LESS_TERMCAP_us=$'\e[4;32m'       # begin underline
+export LESS_TERMCAP_so=$'\e[1;33;41m'    # begin standout-mode - info box
+export LESS_TERMCAP_me=$'\e[m'           # end mode
+export LESS_TERMCAP_ue=$'\e[m'           # end underline
+export LESS_TERMCAP_se=$'\e[m'           # end standout-mode

--- a/.config/zsh/message.zsh
+++ b/.config/zsh/message.zsh
@@ -2,15 +2,15 @@
 # Ascii art taken from:
 #       https://github.com/kadekillary/dotfiles/blob/master/nvim/init.vim
 
-secondMsg=("\t\t    Good luck with your hacking! 😎")
-secondMsg+=("\t\t     What are we hacking today?👨‍💻")
-sizeSecond=${#secondMsg[@]}
-random=$(shuf -i 1-$sizeSecond -n 1)
-secondMsg="${secondMsg[$random]}"
+secondMsgArr=("\t\t    Good luck with your hacking! 😎")
+secondMsgArr+=("\t\t     What are we hacking today?👨‍💻")
+sizeSecond=${#secondMsgArr[@]}
+random=$(shuf -i 1-"$sizeSecond" -n 1)
+secondMsg="${secondMsgArr[$random]}"
 
 autoload colors; colors
-message=$(< $ZDOTDIR"/message.txt")
-echo $fg[red]$message
+message="$(< "$ZDOTDIR/message.txt")"
+echo "${fg[red]}$message"
 echo
-echo $fg[yellow]"\t\t\tWelcome $USER to Zsh"
-echo $secondMsg
+echo "${fg[yellow]}\t\t\tWelcome $USER to Zsh"
+echo "$secondMsg"

--- a/.zshenv
+++ b/.zshenv
@@ -1,1 +1,1 @@
-export ZDOTDIR=$HOME"/.config/zsh"
+export ZDOTDIR="$HOME/.config/zsh"

--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ Download these themes and save them on the previously created folder:
 Download this file and save it on `~/.config/zsh/`:
 [aliases.zsh](./.config/zsh/aliases.zsh)
 
+## Zsh man pages color
+Download the `color-manpages.zsh` [file](./.config/zsh/color-manpages.zsh) and save it on the same folder where you just stored the aliases.
+
 ## Welcome message
 Download the two `message.*` files ([the zhs](./.config/zsh/message.zsh) one and the [the txt](./.config/zsh/message.txt) one) and save them in the same folder where the aliases are.
 


### PR DESCRIPTION
# Description

I decide to update how I use variables in the script after I did some tutorials with shell scripting and also because I used a linter. Some of the changes might not be necessary for ZSH but is still good to try and make clear what I wanted on each variable. I also used the `$ZDOTDIR` variable on some of the paths that I had because I was typing the full path instead, which is not necessary at all.